### PR TITLE
Add public organization profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,58 @@
+![Testcontainers](https://raw.githubusercontent.com/testcontainers/.github/main/profile/logo.png)
+
+<html>
+<h3 align="center">
+    <a href="https://testcontainers.com/">Website</a>
+    <span> · </span>
+    <a href="https://testcontainers.com/guides/">Guides</a>
+    <span> · </span>
+    <a href="https://slack.testcontainers.org/">Slack</a>
+    <span> · </span>
+    <a href="https://twitter.com/testcontainers">Twitter</a>
+</h3>
+</html>
+
+## What is Testcontainers?
+
+Testcontainers is a testing library
+that provides easy and lightweight APIs for bootstrapping integration tests with real services 
+wrapped in Docker containers. 
+Using Testcontainers, you can write tests talking to the same type of services you use in production
+without mocks or in-memory services.
+
+## Implementations
+
+Testcontainers is available for the following languages:
+
+* [Testcontainers for .NET](https://dotnet.testcontainers.org/)
+* [Testcontainers for Go](https://golang.testcontainers.org/)
+* [Testcontainers for Java](https://java.testcontainers.org/)
+* [Testcontainers for Node.js](https://node.testcontainers.org/)
+
+## Modules Catalog
+
+Testcontainers offers modules with preconfigured implementations for popular services 
+such as databases, message brokers, and more. 
+Find the full list of modules in the [Testcontainers Module Catalog](https://testcontainers.com/modules/). 
+If you own a Testcontainers module implementation, please submit it to the catalog by creating a pull request to [this repository](https://github.com/testcontainers/community-module-registry).
+
+## Getting Started
+
+To get started with Testcontainers, 
+please refer to the [What is Testcontainers, and why should you use it?](https://testcontainers.com/guides/introducing-testcontainers/) guide. 
+We recommend you to start with the [Getting Started](https://testcontainers.com/getting-started/) guide.
+
+## How to start?
+
+* [Getting started with Testcontainers for .Net](https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet/)
+* [Getting started with Testcontainers for Go](https://testcontainers.com/guides/getting-started-with-testcontainers-for-go/)
+* [Getting started with Testcontainers for Java](https://testcontainers.com/guides/getting-started-with-testcontainers-for-java/)
+* [Getting started with Testcontainers for Node.js](https://testcontainers.com/guides/getting-started-with-testcontainers-for-nodejs/)
+
+## Testcontainers Desktop
+
+The [Testcontainers Desktop](https://testcontainers.com/desktop/) is a free companion app for open source Testcontainers libraries that makes local development and testing with real dependencies simple.
+Read more about Testcontainers Desktop in the 
+[Simple local development with Testcontainers Desktop](https://testcontainers.com/guides/simple-local-development-with-testcontainers-desktop/) guide.
+
+[![Introducing Testcontainers Desktop](https://img.youtube.com/vi/uRWKTNbOX-8/maxresdefault.jpg)](https://youtu.be/uRWKTNbOX-8)

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,11 +14,8 @@
 
 ## What is Testcontainers?
 
-Testcontainers is a testing library
-that provides easy and lightweight APIs for bootstrapping integration tests with real services 
-wrapped in Docker containers. 
-Using Testcontainers, you can write tests talking to the same type of services you use in production
-without mocks or in-memory services.
+Testcontainers is an open source framework for providing throwaway, lightweight instances of databases, message brokers, web browsers, 
+or just about anything that can run in a Docker container.
 
 ## Implementations
 
@@ -28,6 +25,14 @@ Testcontainers is available for the following languages:
 * [Testcontainers for Go](https://golang.testcontainers.org/)
 * [Testcontainers for Java](https://java.testcontainers.org/)
 * [Testcontainers for Node.js](https://node.testcontainers.org/)
+
+### Community Projects
+
+* [Testcontainers for Clojure](https://cljdoc.org/d/clj-test-containers/clj-test-containers/)
+* [Testcontainers for Haskell](https://github.com/testcontainers/testcontainers-hs)
+* [Testcontainers for Python](https://testcontainers-python.readthedocs.io/en/latest/)
+* [Testcontainers for Ruby](https://github.com/testcontainers/testcontainers-ruby)
+* [Testcontainers for Rust](https://docs.rs/testcontainers/latest/testcontainers/)
 
 ## Modules Catalog
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -33,6 +33,7 @@ Testcontainers is available for the following languages:
 * [Testcontainers for Python](https://testcontainers-python.readthedocs.io/en/latest/)
 * [Testcontainers for Ruby](https://github.com/testcontainers/testcontainers-ruby)
 * [Testcontainers for Rust](https://docs.rs/testcontainers/latest/testcontainers/)
+* [Testcontainers for Scala](https://github.com/testcontainers/testcontainers-scala/)
 
 ## Modules Catalog
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -42,7 +42,8 @@ Testcontainers is available for the following languages:
 Testcontainers offers modules with preconfigured implementations for popular services 
 such as databases, message brokers, and more. 
 Find the full list of modules in the [Testcontainers Module Catalog](https://testcontainers.com/modules/). 
-If you own a Testcontainers module implementation, please submit it to the catalog by creating a pull request to [this repository](https://github.com/testcontainers/community-module-registry).
+If you own a Testcontainers module implementation,
+please submit it to the catalog by creating a pull request to [this repository](https://github.com/testcontainers/community-module-registry).
 
 ## Getting Started
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -59,7 +59,7 @@ We recommend you to start with the [Getting Started](https://testcontainers.com/
 
 ## Testcontainers Desktop
 
-The [Testcontainers Desktop](https://testcontainers.com/desktop/) is a free companion app for open source Testcontainers libraries that makes local development and testing with real dependencies simple.
+[Testcontainers Desktop](https://testcontainers.com/desktop/) is a free companion app for the open source Testcontainers libraries that enriches the Testcontainers user-experience makes local development and testing with real dependencies even simpler.
 Read more about Testcontainers Desktop in the 
 [Simple local development with Testcontainers Desktop](https://testcontainers.com/guides/simple-local-development-with-testcontainers-desktop/) guide.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -52,7 +52,7 @@ We recommend you to start with the [Getting Started](https://testcontainers.com/
 
 ## How to start?
 
-* [Getting started with Testcontainers for .Net](https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet/)
+* [Getting started with Testcontainers for .NET](https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet/)
 * [Getting started with Testcontainers for Go](https://testcontainers.com/guides/getting-started-with-testcontainers-for-go/)
 * [Getting started with Testcontainers for Java](https://testcontainers.com/guides/getting-started-with-testcontainers-for-java/)
 * [Getting started with Testcontainers for Node.js](https://testcontainers.com/guides/getting-started-with-testcontainers-for-nodejs/)

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,6 @@
-![Testcontainers](https://raw.githubusercontent.com/testcontainers/.github/main/profile/logo.png)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/testcontainers/.github/main/profile/logo.png">
+</p>
 
 <html>
 <h3 align="center">


### PR DESCRIPTION
## What does this PR do?

Adds a public page describing the Testcontainers project to the GitHub org, that will be rendered at https://github.com/testcontainers.

## Why is it important?

Provide new users that discover Testcontainers on GitHub with more context and links to helpful resources, for a better getting-started experience.
